### PR TITLE
Add proper Totem Models for Horde

### DIFF
--- a/Updates/020_Totem_Models.sql
+++ b/Updates/020_Totem_Models.sql
@@ -1,0 +1,3 @@
+# Use proper Totem Models for Horde Totems.
+INSERT INTO `creature_model_race`(`modelid`,`racemask`,`creature_entry`,`modelid_racial`)
+VALUES(19071, 690, 0, 4590),(19073, 690, 0, 4588),(19074, 690, 0, 4589),(19075, 690, 0, 4587);


### PR DESCRIPTION
Until now, the Draenai Models were
used for Horde Totems. This change
will make sure that the correct
Totem Model is used for Horde Totems.
