### PR TITLE
Add MySQL hostname user configuration variable to Windows_Install_Script.bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ with creatures, items, objects, quests, etc.
 It must be applied after creating the `mangos` database from your CMaNGOS core distribution [cmangos-tbc] from [CMaNGOS Project].
 
 For Easy Installation Edit The Following Windows Batch File `./Windows_Install_Script.bat` if you are a Windows User and configure
-the Installation Options Setting Your MYSQL Database Names, Passwords and Source Folders.
+the Installation Options Setting Your MYSQL Database Names, Passwords and Source Folders. Optionally specify an alternate hostname
+to make the script run the SQL on a remote MySQL database server (eg: a Linux host) - requires additional user/privilege creation
+on the remote MySQL server).
 
 It will provide you a Menu With Various Installation Options and Configurations That Have Greatly Simplified The Process.
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ with creatures, items, objects, quests, etc.
 
 It must be applied after creating the `mangos` database from your CMaNGOS core distribution [cmangos-tbc] from [CMaNGOS Project].
 
-For Easy Installation Edit The Following Windows Batch File `./Windows_Install_Script.bat` if you are a Windows User and configure
-the Installation Options Setting Your MYSQL Database Names, Passwords and Source Folders. Optionally specify an alternate hostname
-to make the script run the SQL on a remote MySQL database server (eg: a Linux host) - requires additional user/privilege creation
-on the remote MySQL server).
+For Easy Installation Edit The Following Windows Batch File `./Windows_Install_Script.bat` if you are a Windows User and configure the Installation Options Setting Your MYSQL Database Names, Passwords and Source Folders. Optionally specify an alternate hostname to make the script run the SQL on a remote MySQL database server (eg: a Linux host - requires additional user/privilege creation on the remote MySQL server).
 
 It will provide you a Menu With Various Installation Options and Configurations That Have Greatly Simplified The Process.
 

--- a/Windows_Install_Script.bat
+++ b/Windows_Install_Script.bat
@@ -4,6 +4,7 @@ REM USER CONFIGURATION REQUIRED FOR AUTOMATIC IMPORT OF DATA - PLEASE UPDATE THI
 REM ########################################################################################################
 SET CMangos="C:\CMangos"
 SET ACID="C:\CMangos\ACID\acid_tbc"
+SET Hostname="localhost"
 SET User="mangos"
 SET Password="mangos"
 SET WorldDB="mangos"
@@ -156,7 +157,7 @@ ECHO.
 ECHO --------------------------------------------------------------
 ECHO PLEASE BE PATIENT WHILE NEW DATA IS IMPORTING TO THE DATABASES
 ECHO --------------------------------------------------------------
-mysql.exe --user=%User% --password=%Password% %WorldDB% < %CurrentVersion%_FULL.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %WorldDB% < %CurrentVersion%_FULL.sql
 ECHO.
 ECHO --------------------
 ECHO REMOVE OLD SQL FILES
@@ -193,7 +194,7 @@ ECHO.
 ECHO --------------------------------------------------------------
 ECHO PLEASE BE PATIENT WHILE NEW DATA IS IMPORTING TO THE DATABASES
 ECHO --------------------------------------------------------------
-mysql.exe --user=%User% --password=%Password% %WorldDB% < %StableVersion%_FULL.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %WorldDB% < %StableVersion%_FULL.sql
 ECHO.
 ECHO --------------------
 ECHO REMOVE OLD SQL FILES
@@ -232,8 +233,8 @@ ECHO.
 ECHO -----------------------------------------------------
 ECHO IMPORT BASE DATA INTO DATABASES - NO CONTENT INCLUDED
 ECHO -----------------------------------------------------
-mysql.exe --user=%User% --password=%Password% %WorldDB% < %CMangos%\sql\base\mangos.sql
-mysql.exe --user=%User% --password=%Password% %CharactersDB% < %CMangos%\sql\base\characters.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %WorldDB% < %CMangos%\sql\base\mangos.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %CharactersDB% < %CMangos%\sql\base\characters.sql
 ECHO.
 ECHO --------------------
 ECHO REMOVE OLD SQL FILES
@@ -261,19 +262,19 @@ ECHO.
 ECHO -----------------------------------------
 ECHO DELETE EXISTING GAME DATA FOR FRESH SETUP
 ECHO -----------------------------------------
-mysql.exe --user=%User% --password=%Password% < Tools\Install_Script_Helpers\TBC-DB_Drop_Mysql.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% < Tools\Install_Script_Helpers\TBC-DB_Drop_Mysql.sql
 ECHO.
 ECHO -------------------------------------------------
 ECHO CREATE MYSQL USER AND NEW REQUIRED GAME DATABASES
 ECHO -------------------------------------------------
-mysql.exe --user=%User% --password=%Password% < %CMangos%\sql\create\db_create_mysql.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% < %CMangos%\sql\create\db_create_mysql.sql
 ECHO.
 ECHO -----------------------------
 ECHO LOAD DATABASE TABLE STRUCTURE 
 ECHO -----------------------------
-mysql.exe --user=%User% --password=%Password% %WorldDB% < %CMangos%\sql\base\mangos.sql
-mysql.exe --user=%User% --password=%Password% %CharactersDB% < %CMangos%\sql\base\characters.sql
-mysql.exe --user=%User% --password=%Password% %RealmdDB% < %CMangos%\sql\base\realmd.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %WorldDB% < %CMangos%\sql\base\mangos.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %CharactersDB% < %CMangos%\sql\base\characters.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %RealmdDB% < %CMangos%\sql\base\realmd.sql
 ECHO.
 ECHO ----------------------------------------------------------------------
 ECHO BUILDING COMPLETE NEW FULL DB FROM NEWEST TBC-DB / CMANGOS / ACID DATA
@@ -290,7 +291,7 @@ ECHO.
 ECHO --------------------------------------------------------------
 ECHO PLEASE BE PATIENT WHILE NEW DATA IS IMPORTING TO THE DATABASES
 ECHO --------------------------------------------------------------
-mysql.exe --user=%User% --password=%Password% %WorldDB% < %CurrentVersion%_FULL.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% %WorldDB% < %CurrentVersion%_FULL.sql
 ECHO.
 ECHO --------------------
 ECHO REMOVE OLD SQL FILES
@@ -320,7 +321,7 @@ ECHO.
 ECHO -----------------------------------------------------------
 ECHO DELETE EXISTING CMANGOS / SD2 GAME DATABASES AND MYSQL USER
 ECHO -----------------------------------------------------------
-mysql.exe --user=%User% --password=%Password% < Tools\Install_Script_Helpers\TBC-DB_Drop_Mysql.sql
+mysql.exe --host=%Hostname% --user=%User% --password=%Password% < Tools\Install_Script_Helpers\TBC-DB_Drop_Mysql.sql
 ECHO.
 ECHO -------------------------------------------------------------
 ECHO ALL DEFAULT DATABASES HAVE BEEN DELETED AND USERS CLEANED OUT 


### PR DESCRIPTION
My first ever pull request - please be gentle!

Here is a tiny contribution that might help some users benefit from the DB install/update script, by being able to run it against a remote MySQL server (not necessarily a Windows server).

I have tested option 1 while using the IP address of a remote MySQL server in the new Hostname variable.
