### PR TITLE
Fix quests 9280, 9369, 9371

### DIFF
--- a/Updates/quest.9280.9369.9371.sql
+++ b/Updates/quest.9280.9369.9371.sql
@@ -1,0 +1,4 @@
+-- q.9280 q.9369 'Replenishing the Healing Crystals'
+UPDATE quest_template SET NextQuestId = 9409 WHERE Entry = 9280 AND Entry = 9369;
+-- q.9371 'Botanist Taerix'
+UPDATE quest_template SET PrevQuestId = 9409 WHERE Entry = 9371;

--- a/Updates/quest.9280.9369.9371.sql
+++ b/Updates/quest.9280.9369.9371.sql
@@ -1,4 +1,4 @@
 -- q.9280 q.9369 'Replenishing the Healing Crystals'
-UPDATE `quest_template` SET NextQuestId = 9409 WHERE Entry = 9280 AND Entry = 9369;
+UPDATE `quest_template` SET NextQuestId = 9409 WHERE entry = 9280 AND entry = 9369;
 -- q.9371 'Botanist Taerix'
-UPDATE `quest_template` SET PrevQuestId = 9409 WHERE Entry = 9371;
+UPDATE `quest_template` SET PrevQuestId = 9409 WHERE entry = 9371;

--- a/Updates/quest.9280.9369.9371.sql
+++ b/Updates/quest.9280.9369.9371.sql
@@ -1,4 +1,4 @@
 -- q.9280 q.9369 'Replenishing the Healing Crystals'
-UPDATE quest_template SET NextQuestId = 9409 WHERE Entry = 9280 AND Entry = 9369;
+UPDATE `quest_template` SET NextQuestId = 9409 WHERE Entry = 9280 AND Entry = 9369;
 -- q.9371 'Botanist Taerix'
-UPDATE quest_template SET PrevQuestId = 9409 WHERE Entry = 9371;
+UPDATE `quest_template` SET PrevQuestId = 9409 WHERE Entry = 9371;


### PR DESCRIPTION
Fixes to Draenei starting zone quests.
Stops Replenishing the Healing Crystals from showing before the quest has been completed.
Stops Botanist Taerix quest from appearing too early.
