### PR TITLE
Fix quest 10538.

### DIFF
--- a/Updates/001_Quest_Template.sql
+++ b/Updates/001_Quest_Template.sql
@@ -1,0 +1,3 @@
+-- Boiling Blood
+UPDATE `quest_template` SET `ReqSourceCount1` = 12 WHERE `entry` = 10538;
+


### PR DESCRIPTION
Updates the max stack of Bleeding Hollow Blood (30425) to 12 rather than 1.

The actual max stack for the item is 20 but only 12 are required to complete the quest.
