### PR TITLE
Classic/UDB - Fix condition for dropping Crudely-written Log, opens quest chain 5128 (Words of the High Chief)

### DIFF
--- a/Updates/TBCDB-Fix_Quests_5123_5128.sql
+++ b/Updates/TBCDB-Fix_Quests_5123_5128.sql
@@ -1,3 +1,3 @@
 -- Fix quest chain 5128 (Words of the High Chief)
 
-UPDATE `mangos`.`conditions` SET `value1` = 5087 WHERE `condition_entry` = 211;
+UPDATE `mangos`.`conditions` SET `value1` = 5121, `type` = 9 WHERE `condition_entry` = 211;

--- a/Updates/TBCDB-Fix_Quests_5123_5128.sql
+++ b/Updates/TBCDB-Fix_Quests_5123_5128.sql
@@ -1,3 +1,3 @@
 -- Fix quest chain 5128 (Words of the High Chief)
 
-UPDATE `mangos`.`conditions` SET `value1` = 5121, `type` = 9 WHERE `condition_entry` = 211;
+UPDATE `conditions` SET `value1` = 5121, `type` = 9 WHERE `condition_entry` = 211;

--- a/Updates/TBCDB-Fix_Quests_5123_5128.sql
+++ b/Updates/TBCDB-Fix_Quests_5123_5128.sql
@@ -1,0 +1,3 @@
+-- Fix quest chain 5128 (Words of the High Chief)
+
+UPDATE `mangos`.`conditions` SET `value1` = 5087 WHERE `condition_entry` = 211;


### PR DESCRIPTION
Backported from UDB.

Not working in TBC only.

Closes:
http://jira.vengeancewow.com/browse/TBC-1570
http://jira.vengeancewow.com/browse/TBC-1682
