### PR TITLE
Fix pillar spawn times to match ClassicDB values (Quest 717 - Tremors of the Earth)

### DIFF
--- a/Updates/go_2848_2858_spawn_fix.sql
+++ b/Updates/go_2848_2858_spawn_fix.sql
@@ -1,0 +1,3 @@
+-- Fix spawn times for Pillar of Opal and Pillar of Amethyst
+
+UPDATE `gameobject` SET `spawntimesecs` = '2' WHERE `id` IN ('2848','2858');


### PR DESCRIPTION
In both TBC-DB and UDB, for some reason we have Pillar of Amethyst (2858) and Pillar of Opal (2848) set to spawn time of 7200. Pillar of Diamond (2842) however has spawn time of 2.

In ClassicDB, we have spawn time of 2 for all three pillars, which I believe to be correct.

Closes:
http://jira.vengeancewow.com/browse/TBC-1685
