### PR TITLE
Classic/UDB - Fix drop requirements for quest 1846 (Dragonmaw Shinbones)

### DIFF
--- a/Updates/quest_1846_fix.sql
+++ b/Updates/quest_1846_fix.sql
@@ -1,0 +1,3 @@
+-- Fix requirements to drop Dragonmaw Shinbones (7131) for quest 1846 (Dragonmaw Shinbones)
+
+UPDATE `quest_template` SET `ReqSourceId1` = '7131' WHERE `entry` = '1846';


### PR DESCRIPTION
Backported from UDB.

Not working in TBC only.

Closes:
http://jira.vengeancewow.com/projects/TBC/issues/TBC-1720
