### PR TITLE
Fix drop chance of item 30689 (Razuun's Orders) for quests 10586, 10603 (Bring Down the Warbringer!)

### DIFF
--- a/Updates/quests_10586_10603_fix.sql
+++ b/Updates/quests_10586_10603_fix.sql
@@ -1,0 +1,3 @@
+-- Fix drop chance of item 30689 (Razuun's Orders) for quests 10586, 10603 (Bring Down the Warbringer!)
+
+UPDATE `creature_loot_template` SET `ChanceOrQuestChance` = '-100' WHERE `entry` = '21287' AND `item` = '30689';


### PR DESCRIPTION
Should be 100% chance drop if you are on the quest. It's currently set to 60%.
This needs to be fixed in both UDB and TBC-DB.

Closes:
http://jira.vengeancewow.com/projects/TBC/issues/TBC-1660
